### PR TITLE
Optimize deterministic ID creation

### DIFF
--- a/src/NServiceBus.Persistence.AzureTable/NServiceBus.Persistence.AzureTable.csproj
+++ b/src/NServiceBus.Persistence.AzureTable/NServiceBus.Persistence.AzureTable.csproj
@@ -7,6 +7,7 @@
     <Description>NServiceBus Azure Table Persistence</Description>
     <RootNamespace>NServiceBus.Persistence.AzureTable</RootNamespace>
     <LangVersion>10.0</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Persistence.AzureTable/SagaPersisters/SagaIdGenerator.cs
+++ b/src/NServiceBus.Persistence.AzureTable/SagaPersisters/SagaIdGenerator.cs
@@ -1,6 +1,10 @@
 ﻿namespace NServiceBus.Persistence.AzureTable
 {
     using System;
+    using System.Buffers;
+#if NETFRAMEWORK
+    using System.Runtime.InteropServices;
+#endif
     using Sagas;
     using System.Security.Cryptography;
     using System.Text;
@@ -32,16 +36,73 @@
             return DeterministicGuid($"{sagaEntityTypeFullName}_{correlationProperty.Name}_{serializedPropertyValue}");
         }
 
+#if NETFRAMEWORK
         static Guid DeterministicGuid(string src)
         {
-            var stringBytes = Encoding.UTF8.GetBytes(src);
-
-            using (var sha1CryptoServiceProvider = SHA1.Create())
+            var byteCount = Encoding.UTF8.GetByteCount(src);
+            var buffer = ArrayPool<byte>.Shared.Rent(byteCount);
+            try
             {
-                var hashedBytes = sha1CryptoServiceProvider.ComputeHash(stringBytes);
-                Array.Resize(ref hashedBytes, 16);
-                return new Guid(hashedBytes);
+                var numberOfBytesWritten = Encoding.UTF8.GetBytes(src.AsSpan(), buffer);
+
+                using var sha1CryptoServiceProvider = SHA1.Create();
+                var guidBytes = sha1CryptoServiceProvider.ComputeHash(buffer, 0, numberOfBytesWritten).AsSpan().Slice(0, 16);
+                if (!MemoryMarshal.TryRead<Guid>(guidBytes, out var deterministicGuid))
+                {
+                    deterministicGuid = new Guid(guidBytes.ToArray());
+                }
+                return deterministicGuid;
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer, clearArray: true);
+            }
+        }
+#endif
+#if NET
+        static Guid DeterministicGuid(string src)
+        {
+            var byteCount = Encoding.UTF8.GetByteCount(src);
+            var stringBuffer = ArrayPool<byte>.Shared.Rent(byteCount);
+            try
+            {
+                var numberOfBytesWritten = Encoding.UTF8.GetBytes(src.AsSpan(), stringBuffer);
+
+                using var sha1CryptoServiceProvider = SHA1.Create();
+                Span<byte> hashBuffer = stackalloc byte[20];
+                if (!sha1CryptoServiceProvider.TryComputeHash(stringBuffer.AsSpan().Slice(0, numberOfBytesWritten), hashBuffer, out _))
+                {
+                    var hashBufferLocal = sha1CryptoServiceProvider.ComputeHash(stringBuffer, 0, numberOfBytesWritten);
+                    hashBufferLocal.CopyTo(hashBuffer);
+                }
+
+                var guidBytes = hashBuffer.Slice(0, 16);
+                return new Guid(guidBytes);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(stringBuffer, clearArray: true);
+            }
+        }
+#endif
+    }
+
+#if NETFRAMEWORK
+    static class SpanExtensions
+    {
+        public static unsafe int GetBytes(this Encoding encoding, ReadOnlySpan<char> src, Span<byte> dst)
+        {
+            if (src.IsEmpty)
+            {
+                return 0;
+            }
+
+            fixed (char* chars = &src.GetPinnableReference())
+            fixed (byte* bytes = &dst.GetPinnableReference())
+            {
+                return encoding.GetBytes(chars, src.Length, bytes, dst.Length);
             }
         }
     }
+#endif
 }


### PR DESCRIPTION
https://github.com/Particular/NServiceBus.Persistence.CosmosDB/pull/300

|                             Method |     Mean |   Error |  StdDev | Ratio |  Gen 0 | Allocated |
|----------------------------------- |---------:|--------:|--------:|------:|-------:|----------:|
|                   Original| 729.7 ns | 2.78 ns | 2.60 ns |  1.00 | 0.0458 |     392 B |
|                        Netframework Optimized | 720.4 ns | 6.16 ns | 5.76 ns |  0.99 | 0.0260 |     224 B |
| Netcore Optimized| 624.1 ns | 3.22 ns | 2.85 ns |  0.86 | 0.0146 |     128 B |

This is something for the master branch I wanted to avoid pushing into the current release just yet. 

The benchmark https://github.com/danielmarbach/MicroBenchmarks/commit/8c5fd4b1671f6aad15f74a238937e9234ebd90f9