### PR TITLE
Add Default credential tests to Storage Table tests

### DIFF
--- a/src/LogicalOutbox.StorageTable.AcceptanceTests/LogicalOutbox.StorageTable.AcceptanceTests.csproj
+++ b/src/LogicalOutbox.StorageTable.AcceptanceTests/LogicalOutbox.StorageTable.AcceptanceTests.csproj
@@ -17,11 +17,21 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="Azure.Data.Tables" Version="12.8.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="9.0.0" GeneratePathProperty="true" />
   </ItemGroup>
 
   <Import Project="Includes.targets" />
+
+  <ItemGroup>
+    <!-- 
+    We decided against introducing a special ApiFlavor template variable into MSBuild for now because eventually
+    we will figure out how to do RBAC with CosmosDB and then this test can be moved into the sharedacceptancetest 
+    folder in the includes.targets 
+    -->
+    <Compile Include="..\SharedAcceptanceTests.StorageTable\When_default_credentials_used.cs" />
+  </ItemGroup>
 
 </Project>

--- a/src/NonTransactionalSagas.StorageTable.AcceptanceTests/NonTransactionalSagas.StorageTable.AcceptanceTests.csproj
+++ b/src/NonTransactionalSagas.StorageTable.AcceptanceTests/NonTransactionalSagas.StorageTable.AcceptanceTests.csproj
@@ -10,6 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="NUnit" Version="3.14.0" />
@@ -23,5 +24,14 @@
   </ItemGroup>
 
   <Import Project="Includes.targets" />
+
+  <ItemGroup>
+    <!-- 
+    We decided against introducing a special ApiFlavor template variable into MSBuild for now because eventually
+    we will figure out how to do RBAC with CosmosDB and then this test can be moved into the sharedacceptancetest 
+    folder in the includes.targets 
+    -->
+    <Compile Include="..\SharedAcceptanceTests.StorageTable\When_default_credentials_used.cs" />
+  </ItemGroup>
 
 </Project>

--- a/src/NonTransactionalSagas.StorageTable.AcceptanceTests/NonTransactionalSagas.StorageTable.AcceptanceTests.csproj
+++ b/src/NonTransactionalSagas.StorageTable.AcceptanceTests/NonTransactionalSagas.StorageTable.AcceptanceTests.csproj
@@ -10,7 +10,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="NUnit" Version="3.14.0" />
@@ -18,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="Azure.Data.Tables" Version="12.8.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="9.0.0" GeneratePathProperty="true" />

--- a/src/NonTxSagasWithConventionalTables.StorageTable.AcceptanceTests/NonTxSagasWithConventionalTables.StorageTable.AcceptanceTests.csproj
+++ b/src/NonTxSagasWithConventionalTables.StorageTable.AcceptanceTests/NonTxSagasWithConventionalTables.StorageTable.AcceptanceTests.csproj
@@ -17,11 +17,21 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="Azure.Data.Tables" Version="12.8.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="9.0.0" GeneratePathProperty="true" />
   </ItemGroup>
 
   <Import Project="Includes.targets" />
+
+  <ItemGroup>
+    <!-- 
+    We decided against introducing a special ApiFlavor template variable into MSBuild for now because eventually
+    we will figure out how to do RBAC with CosmosDB and then this test can be moved into the sharedacceptancetest 
+    folder in the includes.targets 
+    -->
+    <Compile Include="..\SharedAcceptanceTests.StorageTable\When_default_credentials_used.cs" />
+  </ItemGroup>
 
 </Project>

--- a/src/PhysicalOutbox.StorageTable.AcceptanceTests/PhysicalOutbox.StorageTable.AcceptanceTests.csproj
+++ b/src/PhysicalOutbox.StorageTable.AcceptanceTests/PhysicalOutbox.StorageTable.AcceptanceTests.csproj
@@ -17,11 +17,21 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="Azure.Data.Tables" Version="12.8.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="9.0.0" GeneratePathProperty="true" />
   </ItemGroup>
 
   <Import Project="Includes.targets" />
+
+  <ItemGroup>
+    <!-- 
+    We decided against introducing a special ApiFlavor template variable into MSBuild for now because eventually
+    we will figure out how to do RBAC with CosmosDB and then this test can be moved into the sharedacceptancetest 
+    folder in the includes.targets 
+    -->
+    <Compile Include="..\SharedAcceptanceTests.StorageTable\When_default_credentials_used.cs" />
+  </ItemGroup>
 
 </Project>

--- a/src/SharedAcceptanceTests.All/ConnectionStringHelper.cs
+++ b/src/SharedAcceptanceTests.All/ConnectionStringHelper.cs
@@ -38,6 +38,11 @@ namespace NServiceBus.Testing
             return string.IsNullOrWhiteSpace(candidate) ? Environment.GetEnvironmentVariable(variable) : candidate;
         }
 
+        public static bool IsRunningWithEmulator(string connectionString) => connectionString is CosmosDbEmulatorConnectionString or AzureTableStorageEmulatorConnectionString;
+
+        const string CosmosDbEmulatorConnectionString = "AccountEndpoint = https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
+        const string AzureTableStorageEmulatorConnectionString = "UseDevelopmentStorage=true";
+
         // Adopted from Cosmos DB Table API SDK that uses similar approach to change the underlying execution
         public static bool IsPremiumEndpoint(string connectionString)
         {

--- a/src/SharedAcceptanceTests.All/SharedAcceptanceTests.All.txt
+++ b/src/SharedAcceptanceTests.All/SharedAcceptanceTests.All.txt
@@ -1,1 +1,1 @@
-src\SharedAcceptanceTests.All contains tests shared betweet all acceptance tests
+src\SharedAcceptanceTests.All contains tests shared between all acceptance tests

--- a/src/SharedAcceptanceTests.RequirePartitionKey/SharedAcceptanceTests.RequirePartitionKey.txt
+++ b/src/SharedAcceptanceTests.RequirePartitionKey/SharedAcceptanceTests.RequirePartitionKey.txt
@@ -1,1 +1,1 @@
-src\SharedAcceptanceTests.RequirePartitionKey contains tests shared betweet PhysicalOutbox.AcceptanceTests and LogicalOutbox.AcceptanceTests projects
+src\SharedAcceptanceTests.RequirePartitionKey contains tests shared between PhysicalOutbox.AcceptanceTests and LogicalOutbox.AcceptanceTests projects

--- a/src/SharedAcceptanceTests.StorageTable/SharedAcceptanceTests.StorageTable.txt
+++ b/src/SharedAcceptanceTests.StorageTable/SharedAcceptanceTests.StorageTable.txt
@@ -1,0 +1,1 @@
+src\SharedAcceptanceTests.StorageTable contains tests shared all projects that use Azure Storage Table projects

--- a/src/SharedAcceptanceTests.StorageTable/When_default_credentials_used.cs
+++ b/src/SharedAcceptanceTests.StorageTable/When_default_credentials_used.cs
@@ -26,7 +26,7 @@
                     DataId = Guid.NewGuid()
                 })))
                 .Done(c => c.SagaReceivedMessage)
-                .Run().ConfigureAwait(false); // TODO find out why the analyzer flags this
+                .Run();
 
             Assert.True(context.SagaReceivedMessage);
         }

--- a/src/SharedAcceptanceTests.StorageTable/When_default_credentials_used.cs
+++ b/src/SharedAcceptanceTests.StorageTable/When_default_credentials_used.cs
@@ -1,0 +1,86 @@
+﻿namespace NServiceBus.AcceptanceTests
+{
+    using System;
+    using System.Data.Common;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using Azure.Data.Tables;
+    using Azure.Identity;
+    using EndpointTemplates;
+    using NUnit.Framework;
+    using Testing;
+
+    public class When_default_credentials_used : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_work()
+        {
+            if (ConnectionStringHelper.IsRunningWithEmulator(this.GetEnvConfiguredConnectionStringByCallerConvention()))
+            {
+                Assert.Ignore("This test uses DefaultAzureCredential which is not supported with the emulator.");
+            }
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointUsingDefaultCredentials>(b => b.When(session => session.SendLocal(new StartSaga1
+                {
+                    DataId = Guid.NewGuid()
+                })))
+                .Done(c => c.SagaReceivedMessage)
+                .Run().ConfigureAwait(false); // TODO find out why the analyzer flags this
+
+            Assert.True(context.SagaReceivedMessage);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool SagaReceivedMessage { get; set; }
+        }
+
+        public class EndpointUsingDefaultCredentials : EndpointConfigurationBuilder
+        {
+            public EndpointUsingDefaultCredentials() =>
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    var builder = new DbConnectionStringBuilder
+                    {
+                        ConnectionString = this.GetEnvConfiguredConnectionStringByCallerConvention()
+                    };
+                    builder.TryGetValue("AccountEndpoint", out var accountEndpoint);
+
+                    var baseUrlTemplate = $"https://{builder["AccountName"]}.{{0}}.{builder["EndpointSuffix"]}";
+                    var tableServiceClient = new TableServiceClient(new Uri(string.Format(baseUrlTemplate, "table")), new DefaultAzureCredential());
+
+                    var persistence = config.UsePersistence<AzureTablePersistence>();
+                    persistence.UseTableServiceClient(tableServiceClient);
+                });
+
+            public class JustASaga : Saga<JustASagaData>, IAmStartedByMessages<StartSaga1>
+            {
+                public JustASaga(Context testContext) => this.testContext = testContext;
+
+                public Task Handle(StartSaga1 message, IMessageHandlerContext context)
+                {
+                    Data.DataId = message.DataId;
+                    testContext.SagaReceivedMessage = true;
+                    MarkAsComplete();
+                    return Task.CompletedTask;
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<JustASagaData> mapper)
+                    => mapper.ConfigureMapping<StartSaga1>(m => m.DataId).ToSaga(s => s.DataId);
+
+                readonly Context testContext;
+            }
+
+            public class JustASagaData : ContainSagaData
+            {
+                public virtual Guid DataId { get; set; }
+            }
+        }
+
+        public class StartSaga1 : ICommand
+        {
+            public Guid DataId { get; set; }
+        }
+    }
+}

--- a/src/SharedAcceptanceTests.StorageTable/When_default_credentials_used.cs
+++ b/src/SharedAcceptanceTests.StorageTable/When_default_credentials_used.cs
@@ -26,7 +26,7 @@
                     DataId = Guid.NewGuid()
                 })))
                 .Done(c => c.SagaReceivedMessage)
-                .Run();
+                .Run().ConfigureAwait(false);
 
             Assert.True(context.SagaReceivedMessage);
         }


### PR DESCRIPTION
We had a hard time and eventually failed to figure out within the timebox we had to add tests for CosmosDB that use the table API. We got weird authentication problems and found no documentation on how to get it running. For now, this PR adds a test to the projects that us storage table only. Better than nothing.