### PR TITLE
[Backport to 5.0] Separate outbox records by endpoint name to enable properly sharing the same collection between endpoints

### DIFF
--- a/src/NServiceBus.Persistence.AzureTable.TransactionalSession/AzureTableControlMessageBehavior.cs
+++ b/src/NServiceBus.Persistence.AzureTable.TransactionalSession/AzureTableControlMessageBehavior.cs
@@ -2,12 +2,14 @@ namespace NServiceBus.TransactionalSession
 {
     using System;
     using System.Threading.Tasks;
+    using Persistence.AzureTable;
     using Pipeline;
 
     sealed class AzureTableControlMessageBehavior : IBehavior<ITransportReceiveContext, ITransportReceiveContext>
     {
         public const string PartitionKeyStringHeaderKey = "NServiceBus.TxSession.AzureTable.PartitionKeyString";
         public const string TableInformationHeaderKey = "NServiceBus.TxSession.AzureTable.TableInformation";
+        public const string OutboxEndpointNameHeaderKey = "NServiceBus.TxSession.AzureTable.OutboxEndpointName";
 
         public Task Invoke(ITransportReceiveContext context, Func<ITransportReceiveContext, Task> next)
         {
@@ -21,6 +23,11 @@ namespace NServiceBus.TransactionalSession
             {
                 var tableInformationInstance = new TableInformation(tableName);
                 context.Extensions.Set(tableInformationInstance);
+            }
+
+            if (context.Message.Headers.TryGetValue(OutboxEndpointNameHeaderKey, out var outboxEndpointName))
+            {
+                context.Extensions.Set(new OutboxSourceEndpointName(outboxEndpointName));
             }
 
             return next(context);

--- a/src/NServiceBus.Persistence.AzureTable.TransactionalSession/AzureTableTransactionalSession.cs
+++ b/src/NServiceBus.Persistence.AzureTable.TransactionalSession/AzureTableTransactionalSession.cs
@@ -8,8 +8,13 @@ namespace NServiceBus.TransactionalSession
         protected override void Setup(FeatureConfigurationContext context)
         {
             // can be a singleton
-            context.Services
+            _ = context.Services
                 .AddSingleton<IOpenSessionOptionsCustomization, SetAsDispatchedHolderOpenSessionOptionCustomization>();
+
+            var endpointName = context.Settings.EndpointName();
+            _ = context.Services
+                .AddSingleton<IOpenSessionOptionsCustomization>(new OutboxEndpointNameOpenSessionOptionCustomization(endpointName));
+
             context.Pipeline.Register(new AzureTableControlMessageBehavior(),
                 "Propagates control message header values to TableEntityPartitionKeys and TableInformation when necessary.");
 

--- a/src/NServiceBus.Persistence.AzureTable.TransactionalSession/OutboxEndpointNameOpenSessionOptionCustomization.cs
+++ b/src/NServiceBus.Persistence.AzureTable.TransactionalSession/OutboxEndpointNameOpenSessionOptionCustomization.cs
@@ -1,7 +1,11 @@
 namespace NServiceBus.TransactionalSession
 {
-    sealed class OutboxEndpointNameOpenSessionOptionCustomization(string endpointName) : IOpenSessionOptionsCustomization
+    sealed class OutboxEndpointNameOpenSessionOptionCustomization : IOpenSessionOptionsCustomization
     {
+        readonly string endpointName;
+
+        public OutboxEndpointNameOpenSessionOptionCustomization(string endpointName) => this.endpointName = endpointName;
+
         public void Apply(OpenSessionOptions options) =>
             options.Metadata[AzureTableControlMessageBehavior.OutboxEndpointNameHeaderKey] = endpointName;
     }

--- a/src/NServiceBus.Persistence.AzureTable.TransactionalSession/OutboxEndpointNameOpenSessionOptionCustomization.cs
+++ b/src/NServiceBus.Persistence.AzureTable.TransactionalSession/OutboxEndpointNameOpenSessionOptionCustomization.cs
@@ -1,0 +1,8 @@
+namespace NServiceBus.TransactionalSession
+{
+    sealed class OutboxEndpointNameOpenSessionOptionCustomization(string endpointName) : IOpenSessionOptionsCustomization
+    {
+        public void Apply(OpenSessionOptions options) =>
+            options.Metadata[AzureTableControlMessageBehavior.OutboxEndpointNameHeaderKey] = endpointName;
+    }
+}

--- a/src/NServiceBus.Persistence.AzureTable/Outbox/LogicalOutboxBehavior.cs
+++ b/src/NServiceBus.Persistence.AzureTable/Outbox/LogicalOutboxBehavior.cs
@@ -15,11 +15,11 @@
     /// </summary>
     public sealed class LogicalOutboxBehavior : IBehavior<IIncomingLogicalMessageContext, IIncomingLogicalMessageContext>
     {
-        internal LogicalOutboxBehavior(TableClientHolderResolver tableClientHolderResolver, TableCreator tableCreator)
+        internal LogicalOutboxBehavior(string endpointName, TableClientHolderResolver tableClientHolderResolver, TableCreator tableCreator)
         {
+            this.endpointName = endpointName;
             this.tableClientHolderResolver = tableClientHolderResolver;
             this.tableCreator = tableCreator;
-
         }
 
         /// <inheritdoc />
@@ -63,7 +63,7 @@
 
             await tableCreator.CreateTableIfNotExists(tableHolder.TableClient, CancellationToken.None).ConfigureAwait(false);
 
-            var outboxRecord = await tableHolder.TableClient.ReadOutboxRecord(context.MessageId, azureStorageOutboxTransaction.PartitionKey.Value, context.Extensions, context.CancellationToken)
+            var outboxRecord = await tableHolder.TableClient.ReadOutboxRecord($"{endpointName}_{context.MessageId}", azureStorageOutboxTransaction.PartitionKey.Value, context.Extensions, context.CancellationToken)
                 .ConfigureAwait(false);
 
             if (outboxRecord is null)
@@ -108,6 +108,7 @@
             throw new Exception("Could not find routing strategy to deserialize.");
         }
 
+        readonly string endpointName;
         readonly TableClientHolderResolver tableClientHolderResolver;
         readonly TableCreator tableCreator;
     }

--- a/src/NServiceBus.Persistence.AzureTable/Outbox/OutboxPersister.cs
+++ b/src/NServiceBus.Persistence.AzureTable/Outbox/OutboxPersister.cs
@@ -10,8 +10,9 @@
 
     class OutboxPersister : IOutboxStorage
     {
-        public OutboxPersister(TableClientHolderResolver tableClientHolderResolver, TableCreator tableCreator)
+        public OutboxPersister(string endpointName, TableClientHolderResolver tableClientHolderResolver, TableCreator tableCreator)
         {
+            this.endpointName = endpointName;
             this.tableClientHolderResolver = tableClientHolderResolver;
             this.tableCreator = tableCreator;
         }
@@ -55,14 +56,18 @@
 
             await tableCreator.CreateTableIfNotExists(tableClientHolder.TableClient, cancellationToken).ConfigureAwait(false);
 
+            var rowKey = context.TryGet<OutboxSourceEndpointName>(out var sourceEndpointName)
+                ? $"{sourceEndpointName.Value}_{messageId}"
+                : OutboxRowKey(messageId);
+
             var outboxRecord = await setAsDispatchedHolder.TableClientHolder.TableClient
-                .ReadOutboxRecord(messageId, partitionKey, context, cancellationToken)
+                .ReadOutboxRecord(rowKey, partitionKey, context, cancellationToken)
                 .ConfigureAwait(false);
 
             setAsDispatchedHolder.Record = outboxRecord;
             setAsDispatchedHolder.PartitionKey = partitionKey;
 
-            return outboxRecord != null ? new OutboxMessage(outboxRecord.Id, outboxRecord.Operations) : null;
+            return outboxRecord != null ? new OutboxMessage(messageId, outboxRecord.Operations) : null;
         }
 
         public Task Store(OutboxMessage message, IOutboxTransaction transaction, ContextBag context, CancellationToken cancellationToken = default)
@@ -79,7 +84,7 @@
 
             var outboxRecord = new OutboxRecord
             {
-                Id = message.MessageId,
+                Id = OutboxRowKey(message.MessageId),
                 Operations = message.TransportOperations,
                 PartitionKey = setAsDispatchedHolder.PartitionKey.PartitionKey
             };
@@ -107,7 +112,10 @@
             return transactionalBatch.ExecuteOperationAsync(operation, cancellationToken);
         }
 
+        string OutboxRowKey(string messageId) => $"{endpointName}_{messageId}";
+
         readonly TableClientHolderResolver tableClientHolderResolver;
         readonly TableCreator tableCreator;
+        readonly string endpointName;
     }
 }

--- a/src/NServiceBus.Persistence.AzureTable/Outbox/OutboxSourceEndpointName.cs
+++ b/src/NServiceBus.Persistence.AzureTable/Outbox/OutboxSourceEndpointName.cs
@@ -1,7 +1,9 @@
 namespace NServiceBus.Persistence.AzureTable
 {
-    sealed class OutboxSourceEndpointName(string value)
+    sealed class OutboxSourceEndpointName
     {
-        public string Value { get; } = value;
+        public OutboxSourceEndpointName(string value) => Value = value;
+
+        public string Value { get; }
     }
 }

--- a/src/NServiceBus.Persistence.AzureTable/Outbox/OutboxSourceEndpointName.cs
+++ b/src/NServiceBus.Persistence.AzureTable/Outbox/OutboxSourceEndpointName.cs
@@ -1,0 +1,7 @@
+namespace NServiceBus.Persistence.AzureTable
+{
+    sealed class OutboxSourceEndpointName(string value)
+    {
+        public string Value { get; } = value;
+    }
+}

--- a/src/NServiceBus.Persistence.AzureTable/Outbox/OutboxStorage.cs
+++ b/src/NServiceBus.Persistence.AzureTable/Outbox/OutboxStorage.cs
@@ -16,8 +16,12 @@
 
         protected override void Setup(FeatureConfigurationContext context)
         {
-            context.Services.AddSingleton<IOutboxStorage, OutboxPersister>();
-            context.Services.AddTransient(provider => new LogicalOutboxBehavior(provider.GetRequiredService<TableClientHolderResolver>(), provider.GetRequiredService<TableCreator>()));
+            context.Services.AddSingleton<IOutboxStorage>(sp =>
+            {
+                var en = context.Settings.EndpointName();
+                return new OutboxPersister(en, sp.GetService<TableClientHolderResolver>(), sp.GetService<TableCreator>());
+            });
+            context.Services.AddTransient(provider => new LogicalOutboxBehavior(context.Settings.EndpointName(), provider.GetRequiredService<TableClientHolderResolver>(), provider.GetRequiredService<TableCreator>()));
 
             context.Pipeline.Register(provider => provider.GetRequiredService<LogicalOutboxBehavior>(), "Behavior that mimics the outbox as part of the logical stage.");
         }

--- a/src/NServiceBus.Persistence.AzureTable/Outbox/OutboxTableExtensions.cs
+++ b/src/NServiceBus.Persistence.AzureTable/Outbox/OutboxTableExtensions.cs
@@ -7,11 +7,11 @@
 
     static class OutboxTableExtensions
     {
-        public static async Task<OutboxRecord> ReadOutboxRecord(this TableClient tableClient, string messageId, TableEntityPartitionKey partitionKey, ContextBag context, CancellationToken cancellationToken = default)
+        public static async Task<OutboxRecord> ReadOutboxRecord(this TableClient tableClient, string rowKey, TableEntityPartitionKey partitionKey, ContextBag context, CancellationToken cancellationToken = default)
         {
             _ = context;
 
-            var retrieveResult = await tableClient.GetEntityIfExistsAsync<OutboxRecord>(partitionKey.PartitionKey, messageId, null, cancellationToken)
+            var retrieveResult = await tableClient.GetEntityIfExistsAsync<OutboxRecord>(partitionKey.PartitionKey, rowKey, null, cancellationToken)
                 .ConfigureAwait(false);
             return retrieveResult.HasValue ? retrieveResult.Value : default;
         }

--- a/src/Persistence.StorageTable.Tests/OutboxPersisterCrossEndpointTests.cs
+++ b/src/Persistence.StorageTable.Tests/OutboxPersisterCrossEndpointTests.cs
@@ -1,0 +1,73 @@
+namespace NServiceBus.PersistenceTesting
+{
+    using System;
+    using System.Threading.Tasks;
+    using Azure.Data.Tables;
+    using Extensibility;
+    using NServiceBus.Outbox;
+    using NServiceBus.Persistence.AzureTable;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class OutboxPersisterCrossEndpointTests
+    {
+        TableClientHolderResolver resolver;
+        TableCreator tableCreator;
+
+        [SetUp]
+        public void SetUp()
+        {
+            resolver = new TableClientHolderResolver(new TableServiceClientProvider(), new TableInformation(SetupFixture.TableName));
+            tableCreator = new TableCreator(tableCreationDisabled: true);
+        }
+
+        [Test]
+        public async Task Should_allow_different_endpoints_to_independently_store_outbox_record_for_same_message()
+        {
+            var partitionKey = Guid.NewGuid().ToString();
+            var messageId = Guid.NewGuid().ToString();
+
+            var endpoint1Persister = new OutboxPersister("endpoint1", resolver, tableCreator);
+            var endpoint2Persister = new OutboxPersister("endpoint2", resolver, tableCreator);
+
+            var ctx1 = CreateContextBag(partitionKey);
+            var ctx2 = CreateContextBag(partitionKey);
+
+            // Both call Get() before either has stored — simulates concurrent processing of the same event
+            _ = await endpoint1Persister.Get(messageId, ctx1);
+            _ = await endpoint2Persister.Get(messageId, ctx2);
+
+            // Endpoint1 stores and commits
+            using var tx1 = await endpoint1Persister.BeginTransaction(ctx1);
+            await endpoint1Persister.Store(new OutboxMessage(messageId, []), tx1, ctx1);
+            await tx1.Commit();
+
+            // Endpoint2 should also be able to store and commit without conflict
+            using var tx2 = await endpoint2Persister.BeginTransaction(ctx2);
+            await endpoint2Persister.Store(new OutboxMessage(messageId, []), tx2, ctx2);
+            await tx2.Commit();
+
+            // Both endpoints should be able to independently retrieve their own outbox record
+            var record1 = await endpoint1Persister.Get(messageId, CreateContextBag(partitionKey));
+            var record2 = await endpoint2Persister.Get(messageId, CreateContextBag(partitionKey));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(record1, Is.Not.Null, "Endpoint1 should find its own outbox record");
+                Assert.That(record2, Is.Not.Null, "Endpoint2 should find its own outbox record");
+            });
+        }
+
+        ContextBag CreateContextBag(string partitionKey)
+        {
+            var contextBag = new ContextBag();
+            contextBag.Set(new TableEntityPartitionKey(partitionKey));
+            return contextBag;
+        }
+
+        class TableServiceClientProvider : IProvideTableServiceClient
+        {
+            public TableServiceClient Client => SetupFixture.TableServiceClient;
+        }
+    }
+}

--- a/src/Persistence.StorageTable.Tests/OutboxPersisterCrossEndpointTests.cs
+++ b/src/Persistence.StorageTable.Tests/OutboxPersisterCrossEndpointTests.cs
@@ -39,12 +39,12 @@ namespace NServiceBus.PersistenceTesting
 
             // Endpoint1 stores and commits
             using var tx1 = await endpoint1Persister.BeginTransaction(ctx1);
-            await endpoint1Persister.Store(new OutboxMessage(messageId, []), tx1, ctx1);
+            await endpoint1Persister.Store(new OutboxMessage(messageId, Array.Empty<TransportOperation>()), tx1, ctx1);
             await tx1.Commit();
 
             // Endpoint2 should also be able to store and commit without conflict
             using var tx2 = await endpoint2Persister.BeginTransaction(ctx2);
-            await endpoint2Persister.Store(new OutboxMessage(messageId, []), tx2, ctx2);
+            await endpoint2Persister.Store(new OutboxMessage(messageId, Array.Empty<TransportOperation>()), tx2, ctx2);
             await tx2.Commit();
 
             // Both endpoints should be able to independently retrieve their own outbox record

--- a/src/Persistence.StorageTable.Tests/PersistenceTestsConfiguration.cs
+++ b/src/Persistence.StorageTable.Tests/PersistenceTestsConfiguration.cs
@@ -49,7 +49,7 @@
                 reader => new JsonTextReader(reader),
                 writer => new JsonTextWriter(writer));
 
-            OutboxStorage = new OutboxPersister(resolver, tableCreator);
+            OutboxStorage = new OutboxPersister("fake", resolver, tableCreator);
 
             GetContextBagForSagaStorage = () =>
             {

--- a/src/Tests/Outbox/LogicalOutboxBehaviorTests.cs
+++ b/src/Tests/Outbox/LogicalOutboxBehaviorTests.cs
@@ -55,30 +55,29 @@
 
             var dispatchProperties = new DispatchProperties
             {
-                DelayDeliveryWith = new DelayedDelivery.DelayDeliveryWith(TimeSpan.FromMinutes(5))
+                DelayDeliveryWith = new DelayedDelivery.DelayDeliveryWith(TimeSpan.FromMinutes(5)),
+                ["Destination"] = "DestinationQueue"
             };
-            dispatchProperties["Destination"] = "DestinationQueue";
 
+            const string endpointName = "endpointName";
             var record = new OutboxRecord
             {
                 PartitionKey = messageId,
                 Dispatched = false,
-                Id = messageId,
-                Operations = new[]
-                {
-                    new TransportOperation("42", dispatchProperties, Array.Empty<byte>(), new Dictionary<string, string>()),
-                }
+                Id = $"{endpointName}_{messageId}",
+                Operations = [new TransportOperation("42", dispatchProperties, Array.Empty<byte>(), [])]
             };
 
             await tableClient.AddEntityAsync(record);
 
-            var containerHolderHolderResolver = new TableClientHolderResolver(new Provider()
-            {
-                Client = tableServiceClient
-            },
+            var containerHolderHolderResolver = new TableClientHolderResolver(
+                new Provider
+                {
+                    Client = tableServiceClient
+                },
                 new TableInformation(tableName));
 
-            var behavior = new LogicalOutboxBehavior(containerHolderHolderResolver, new TableCreator(false));
+            var behavior = new LogicalOutboxBehavior(endpointName, containerHolderHolderResolver, new TableCreator(false));
 
             var testableContext = new TestableIncomingLogicalMessageContext
             {

--- a/src/Tests/Outbox/LogicalOutboxBehaviorTests.cs
+++ b/src/Tests/Outbox/LogicalOutboxBehaviorTests.cs
@@ -65,7 +65,10 @@
                 PartitionKey = messageId,
                 Dispatched = false,
                 Id = $"{endpointName}_{messageId}",
-                Operations = [new TransportOperation("42", dispatchProperties, Array.Empty<byte>(), [])]
+                Operations = new[]
+                {
+                    new TransportOperation("42", dispatchProperties, Array.Empty<byte>(), new Dictionary<string, string>()),
+                }
             };
 
             await tableClient.AddEntityAsync(record);


### PR DESCRIPTION
Backport of: 
- https://github.com/Particular/NServiceBus.Persistence.AzureTable/pull/1211

to `release-5.0` to fix #1116 